### PR TITLE
fix: Fix Invalid Category for Crate Publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ license = "MIT"
 description = "Command Line Interface (CLI) for stress testing for competitive programming contest"
 readme = "README.md"
 repository = "https://github.com/LuchoBazz/quicktest"
-keywords = ["cli", "stress-testing", "cp-tool", "testing", "testing-tool"]
-categories = ["cli"]
+keywords = ["cli", "command-line-interface", "stress-testing", "cp-tool", "testing", "testing-tool"]
+categories = ["command-line-interface"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
# Summary

This Pull Request addresses an issue encountered during the publishing process of the crate to crates.io. Specifically, it resolves the error caused by the use of an unsupported category slug, cli, in the Cargo.toml file.

**Key Changes:**
- Updated the Cargo.toml to include a valid category slug as per the guidelines provided by crates.io.