### PR TITLE
chore: Update Project Version to 1.0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quicktest"
-version = "1.0.6"
+version = "1.0.7"
 authors = ["Luis Miguel Báez <es.luismiguelbaez@gmail.com>"]
 license = "MIT"
 description = "Command Line Interface (CLI) for stress testing for competitive programming contest"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,7 +3,7 @@
 Binary releases can be downloaded manually at:
 https://github.com/LuchoBazz/quicktest/releases
 
-### 1.0.7 / 2024.10.21
+### 1.0.7 / 2024.10.22
 
 - chore: add GitHub actions configuration for windows (#146)
 - chore: Update Dependency Versions (#145)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,12 @@
 Binary releases can be downloaded manually at:
 https://github.com/LuchoBazz/quicktest/releases
 
+### 1.0.7 / 2024.10.21
+
+- chore: add GitHub actions configuration for windows (#146)
+- chore: Update Dependency Versions (#145)
+- chore: Update Rust Version to 1.79 (#144)
+- docs: Add Disclaimer to README Regarding Platform Support (#147)
 
 ### 1.0.6 / 2024.10.20
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ iwr https://luchobazz.github.io/quicktest/install/install.ps1 -useb | iex
 Using Shell:
 
 ```shell
-curl -fsSL https://luchobazz.github.io/quicktest/install/install.sh | v=1.0.1  sh
+curl -fsSL https://luchobazz.github.io/quicktest/install/install.sh | v=1.0.7  sh
 ```
 
 Please open a new terminal, or run the following in the existing one `source ~/.zshrc` or `source ~/.bashrc` as appropriate


### PR DESCRIPTION
## Summary

### 1.0.7 / 2024.10.21

- chore: add GitHub actions configuration for windows (#146)
- chore: Update Dependency Versions (#145)
- chore: Update Rust Version to 1.79 (#144)
- docs: Add Disclaimer to README Regarding Platform Support (#147)