### PR TITLE
Fix: Use correct output and expected files for test comparison

### DIFF
--- a/src/controllers/cmd_cmp_async.rs
+++ b/src/controllers/cmd_cmp_async.rs
@@ -76,8 +76,8 @@ impl CmpController {
             current_case: None,
             state_counter: StateCounter::default(),
             file_in: format!("{}/{}", &root[..], QTEST_INPUT_FILE),
-            file_out: format!("{}/{}", &root[..], QTEST_INPUT_FILE),
-            file_expected: format!("{}/{}", &root[..], QTEST_INPUT_FILE),
+            file_out: format!("{}/{}", &root[..], QTEST_OUTPUT_FILE),
+            file_expected: format!("{}/{}", &root[..], QTEST_EXPECTED_FILE),
         }
     }
 


### PR DESCRIPTION
The file comparison logic within the test library had a bug where
both `file_out` and `file_expected` were incorrectly assigned the
path to the input file (`QTEST_INPUT_FILE`). This resulted in tests
always comparing the input file with itself, rendering the comparison
meaningless.

This commit corrects the assignments:
- `file_out` now points to the actual generated output file.
- `file_expected` now points to the predefined expected file.

This ensures that the test library accurately verifies the generated
output against the expected results.